### PR TITLE
Add pre-commit hooks for type checking and tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+# Pre-commit hooks configuration
+# Install: pip install pre-commit && pre-commit install
+# Run manually: pre-commit run --all-files
+
+repos:
+  # Standard pre-commit hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+
+  # Local hooks for project-specific checks
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy
+        entry: mypy istanbul_game
+        language: system
+        types: [python]
+        pass_filenames: false
+        always_run: true
+
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        types: [python]
+        pass_filenames: false
+        always_run: true

--- a/README.md
+++ b/README.md
@@ -10,6 +10,20 @@ Install the package in development mode with testing dependencies:
 pip install -e ".[dev]"
 ```
 
+### Pre-commit Hooks
+
+Set up pre-commit hooks to run type checking and tests before each commit:
+
+```bash
+pre-commit install
+```
+
+This will run `mypy` and `pytest` automatically on every commit. To run hooks manually:
+
+```bash
+pre-commit run --all-files
+```
+
 ## Development Commands
 
 ### Running Tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dev = [
     "pytest>=7.4.0",
     "pytest-cov>=4.1.0",
     "mypy>=1.7.0",
+    "pre-commit>=3.6.0",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary

- Add pre-commit hooks that run mypy and pytest before each commit
- Include standard pre-commit hooks for trailing whitespace, end-of-file fixes, YAML checks, and large file detection
- Add `pre-commit` to dev dependencies
- Update README with setup instructions

## Setup Instructions

After cloning/pulling this change, run:

```bash
# Install dependencies (including pre-commit)
pip install -e ".[dev]"

# Install the git hooks
pre-commit install
```

This will configure git to automatically run mypy and pytest before each commit. If either fails, the commit will be blocked.

### Manual hook execution

To run the hooks manually without committing:

```bash
pre-commit run --all-files
```

### Bypassing hooks (not recommended)

In rare cases where you need to commit despite hook failures:

```bash
git commit --no-verify -m "message"
```

## No additional GitHub configuration required

The hooks run locally via git's pre-commit mechanism. No GitHub Actions or repository settings changes are needed.

## Test plan

- [ ] Install with `pip install -e ".[dev]"`
- [ ] Run `pre-commit install`
- [ ] Make a small change and verify hooks run on commit
- [ ] Verify `pre-commit run --all-files` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)