### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run pre-commit checks
+        run: pre-commit run --all-files


### PR DESCRIPTION
## Summary

Add GitHub Actions workflow that runs the same checks as the pre-commit hooks.

## When CI runs

- On pull requests to main/master (blocks merge if checks fail)
- On pushes to main/master

## Running checks locally

The CI runs `pre-commit run --all-files`, which is exactly what you run locally:

```bash
# One-time setup
pip install -e ".[dev]"
pre-commit install

# Run checks manually (same as CI)
pre-commit run --all-files
```

This ensures local development and CI are always in sync.

## Test plan

- [ ] Verify GitHub Actions runs on this PR
- [ ] Verify checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)