### PR TITLE
Add LLM player design document

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,102 @@
+# Roadmap
+
+## Goal
+
+Enable a full game session where each player is independently controlled by either a
+human at a terminal or an LLM. The physical game (board, tiles, pieces, dice, card decks)
+remains the authoritative source for random elements; the engine records and validates
+the game sequence and drives LLM turns.
+
+---
+
+## Milestones
+
+### 1. LLM-ready engine interfaces *(in progress — see `designs/DESIGN-LLM-PLAYER.md`)*
+
+Before any interactive play is possible, the engine needs to be able to report what
+actions are legal at any moment and describe the current game state in a way an LLM
+can reason about.
+
+- Refactor police station handler to remove temporary player relocation
+- `GameState.is_valid_action(action) -> bool` — pure predicate, no crash on invalid input
+- `GameState.legal_actions() -> list[PlayerAction]` — exact set of legal actions now
+- `GameState.describe()` — structured game state snapshot for LLM consumption
+- Sentinel value strategy for externally-resolved parameters (dice rolls, demand draws,
+  fountain recall, sultan's palace wildcard goods)
+
+### 2. Interactive game runner
+
+The existing runner replays a pre-recorded CSV; we need one that drives play forward
+interactively, prompting each player for their move in turn.
+
+- Terminal-based runner that loops over turns and phases
+- Game state display after each action (human-readable, not just JSON)
+- Human player input: present legal actions as a numbered menu or accept structured text
+- Configuration: specify which player colors are human vs. LLM at startup
+
+### 3. Physical input handling
+
+Many game events are resolved by physical components (dice, card decks). The interactive
+runner must prompt the operator to provide these values and feed them back into the engine
+as the concrete action parameters that currently use sentinel values.
+
+- After an action with an `UNRESOLVED_ROLL` sentinel is chosen: prompt for dice result
+- After a market sale with `UNRESOLVED_DEMAND` sentinel: prompt for the new demand card drawn
+- Caravansary card draws: prompt for which card(s) are available from the physical deck top
+- Game setup: prompt for initial tile layout, governor/smuggler starting positions, initial
+  player cards
+
+**Open design question — card deck model:**
+The game uses a shared card deck (Caravansary draws, initial player hands) and a separate
+market demand deck. Two main options:
+
+- *Fully physical*: the deck is never modelled digitally; every draw prompts the operator
+  to draw and input. Simple, no shuffling logic needed, works naturally with the physical game.
+- *Digital tracking*: the engine tracks deck contents and validates/randomises draws. Needed
+  if playing without a physical copy (e.g., pure LLM vs. LLM games).
+
+For the near-term goal of augmenting a physical game session, the fully-physical approach
+is likely the path of least resistance. The deck model design should be revisited before
+milestone 3 implementation begins.
+
+### 4. Takeback support
+
+Allowing a move to be undone is important for human usability and for correcting LLM
+mistakes or mis-inputs.
+
+The path of least resistance: the runner records the full ordered sequence of actions
+taken since game start (externally-resolved values baked in). A takeback replays the
+sequence from the initial state, omitting the last N actions. This is O(game length)
+but games are short enough that this is acceptable; checkpoint-based approaches can be
+considered later if needed.
+
+- Action history log maintained by the runner
+- `takeback` command (or menu option) available at any input prompt
+- Specify how many actions to undo (default 1); display the action(s) being removed before
+  confirming
+- After replay, resume interactive play from the restored state
+
+### 5. LLM player integration
+
+Wire up the LLM API to drive player turns automatically when a player's color is
+configured as LLM-controlled.
+
+- Call `legal_actions()` and `describe()` to construct the LLM prompt
+- Parse the LLM's response to identify which action was chosen
+- Prompt the operator to resolve any sentinel values in the chosen action (dice roll,
+  card draw) before submitting to `take_action()`
+- Retry or surface an error if the LLM selects an action that fails validation (should be
+  rare once the candidate generator is correct, but the interface must not crash)
+- Configuration: model selection, API key handling
+
+---
+
+## Cross-cutting notes
+
+- **Replay compatibility:** action history entries must be serialisable in the existing
+  JSON/CSV formats so that a session can be saved and resumed or analysed post-game.
+- **Mixed sessions:** a single game can have any combination of human and LLM players;
+  the runner treats them identically except for how the move is obtained.
+- **Dice and cards for LLM players:** when an LLM player selects a dice-bearing action,
+  the operator rolls the physical dice (or the engine prompts for input) just as for a
+  human player — the LLM selects the intent, the physical world provides the outcome.

--- a/designs/DESIGN-LLM-PLAYER.md
+++ b/designs/DESIGN-LLM-PLAYER.md
@@ -1,155 +1,245 @@
 # Design: LLM Player Support
 
-> **Executive summary:** This plan introduces LLM player support for the Istanbul game
-> engine through three sequential phases: a prerequisite refactor to eliminate the police
-> station temporary-relocation hack, extraction of a pure `is_valid_action()` predicate,
-> and implementation of candidate generators feeding a `legal_actions()` API plus a
-> `describe()` state snapshot. Sentinel values are used only for genuinely random
-> externally-resolved parameters (dice rolls, demand card draws); all other parameters
-> are enumerated in full. One open design question must be resolved before Phase 2
-> implementation: the multi-step interaction protocol for dice-dependent red tile
-> decisions at the Tea House and Black Market (see "Dice and red tile sequencing" below).
+> **Executive summary:** This plan introduces LLM player support through a layered
+> architecture across four phases. Phase 0 replaces the engine's compound action types
+> (which fuse player intent with random outcomes) with a sub-step model: actions that
+> involve dice or card draws are decomposed into sequential steps, each taken by the
+> appropriate actor — either the current player or a configurable randomness resolver.
+> This also cleanly supersedes the police station temporary-relocation hack. Phases 1–2
+> add a pure `is_valid_action()` predicate and `legal_actions()` API on top of the
+> refactored engine. Phase 3 adds a separate JSON interface module exposing the engine
+> state and actions in a tool-call format suitable for both LLM and human interfaces.
+> No open design questions remain before implementation can begin.
 
-This document describes the plan for enabling an LLM to act as one or more players
-in the Istanbul game engine. The approach is to expose a `legal_actions()` API that
-returns the exact set of valid actions at any point in the game, plus a game-state
-description suitable for LLM consumption.
+---
 
 ## Goals
 
-- `GameState.legal_actions() -> list[PlayerAction]` — returns exactly the legal actions
-  available to the current player at this moment (no illegal actions included, no legal
-  actions omitted).
-- `GameState.is_valid_action(action) -> bool` — pure predicate, never raises, replaces
-  assertion-based validation as the source of truth. `take_action()` continues to assert
-  on this, but callers (including the LLM interface) can check without crashing.
-- Clean up the police station temporary-relocation hack as a prerequisite, since it
-  makes the validator structurally awkward.
+- Decompose compound actions into discrete per-actor sub-steps, cleanly separating
+  player decisions from random outcomes.
+- `GameState.is_valid_action(action) -> bool` — pure predicate, never raises.
+- `GameState.legal_actions() -> list[PlayerAction]` — exact set of legal actions for
+  the current actor at this moment.
+- A separate `istanbul_game/interface.py` module that translates engine state and actions
+  into a JSON tool-call representation, usable by both LLM and human interfaces.
 
-## Phase 0: Refactor Police Station Temporary Relocation
+---
 
-### Problem
-
-`_handle_police_station_action` (game.py:518–542) temporarily overwrites
-`player_state.location` and the tile's `players` sets so that recursive sub-handlers see
-the player as being at the destination tile. A comment acknowledges this is an oversight.
-This pattern makes it impossible to validate a `PoliceStationAction`'s sub-action without
-actually relocating, and it makes handlers harder to test in isolation.
-
-### Solution: `_execute_tile_action_at(action, location)`
-
-Extract a dispatcher method that routes a tile action to the correct handler, using
-an explicit `location` argument rather than reading `player_state.location`. Both the
-main `take_action()` and the police station handler call this method. Handlers are
-refactored to receive the resolved `tile` and `tile_state` as parameters instead of
-computing them from player location.
+## Architectural Layers
 
 ```
-_execute_tile_action_at(action: PlaceTileAction | GreenTileAction, location: Location)
-    tile = location_map[location]
-    tile_state = tile_states[tile]
-    dispatch to the appropriate handler, passing tile and tile_state explicitly
+┌─────────────────────────────────┐
+│   Runner / LLM integration      │  drives the game loop, routes to player/resolver
+├─────────────────────────────────┤
+│   interface.py                  │  JSON ↔ Python action/state translation
+├─────────────────────────────────┤
+│   GameState / TurnState         │  engine: validation, state mutation, sub-step tracking
+│   actions.py (revised)          │  decomposed action types
+└─────────────────────────────────┘
 ```
 
-**Changes to handlers:** Each `_handle_X` method receives `tile: Tile` and
-`tile_state: TileState` as parameters, dropping the `self.location_map[player_state.location]`
-call. The tile-identity assertions (`assert tile is Tile.FOO`) become internal sanity checks
-rather than the primary validation mechanism.
+The engine is unaware of JSON. The interface module is unaware of the runner. The runner
+knows both.
 
-**Police station handler becomes:**
+---
+
+## Phase 0: Sub-step Engine Model
+
+### Problem with compound actions
+
+Several existing action types fuse a player's intent with a random outcome in a single
+object: `TeaHouseAction(call, roll)`, `BlackMarketAction(good, roll)`,
+`EncounterGovernor(gain, cost, roll)`, `EncounterSmuggler(gain, cost, roll)`,
+`MarketAction(goods, new_demand)`. This makes it impossible for the player to make a
+decision *after* seeing the random outcome (most critically, whether to use the red tile),
+and forces awkward sentinel-value workarounds at the interface layer.
+
+`PoliceStationAction(location, sub_action)` has a related problem: it embeds a nested
+action and the handler resorts to temporarily relocating the player so sub-handlers see
+the right tile. Both issues share the same root cause — the engine has no concept of
+"the current step within a turn."
+
+### Solution: sub-step tracking in TurnState
+
+Extend `TurnState` with three new fields:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `current_actor` | `ActorType` | `PLAYER` or `RESOLVER` |
+| `pending_sub_step` | `SubStepType \| None` | What the current actor must provide next |
+| `dispatched_location` | `Location \| None` | Effective tile location during a police station dispatch |
+
+`pending_sub_step` is one of: `AWAITING_DICE_ROLL`, `AWAITING_SECOND_DICE_ROLL`,
+`AWAITING_RED_TILE_DECISION`, `AWAITING_DEMAND_DRAW`.
+
+When `pending_sub_step` is not None, `legal_actions()` returns only the actions
+appropriate to that sub-step (resolver or player depending on `current_actor`). Phase
+advancement does not happen until the sub-step sequence completes.
+
+### New and revised action types
+
+**Decomposed player intent actions** (replace the compound types):
+
+| New action | Replaces | Notes |
+|-----------|----------|-------|
+| `TeaHouseCall(call: int)` | `TeaHouseAction` | Player half only |
+| `BlackMarketGoodChoice(good: Good)` | `BlackMarketAction` | Player half only |
+| `MarketGoodsChoice(goods: Counter[Good])` | `MarketAction` | Player half only; no `new_demand` |
+| `SendFamilyMember(location: Location)` | `PoliceStationAction` | Sub-action handled separately via dispatch context |
+| `EncounterGovernorIntent(gain: Card, cost: Card \| Pay)` | `EncounterGovernor` | Player half only |
+| `EncounterSmugglerIntent(gain: Good, cost: Good \| Pay)` | `EncounterSmuggler` | Player half only |
+| `RedTileDecision(use: bool, method: str \| None, die_index: int \| None)` | *(new)* | Player follow-up after seeing dice |
+
+**Resolver actions** (new; taken by the randomness resolver, not the player):
+
+| Action | Triggers when |
+|--------|--------------|
+| `DiceRoll(result: tuple[int, int])` | `pending_sub_step` is `AWAITING_DICE_ROLL` or `AWAITING_SECOND_DICE_ROLL` |
+| `DemandDraw(demand: Counter[Good])` | `pending_sub_step` is `AWAITING_DEMAND_DRAW` |
+
+**Unchanged action types:** all movement actions, `Pay`, `YieldTurn`, `ChooseReward`,
+`SultansPalaceAction`, `MosqueAction`, `FountainAction`, `GenericTileAction`,
+`CaravansaryAction`, `SkipTileAction`, and all card actions (`OneGood`, `FiveLira`,
+`ArrestFamily`, `YellowTile`, `GreenTile`, `SellAny`, `DoubleCard`).
+
+### Sub-step sequences
+
+**Tea House:**
+1. `TeaHouseCall(call)` [PLAYER] → `pending_sub_step = AWAITING_DICE_ROLL`, `current_actor = RESOLVER`
+2. `DiceRoll(result)` [RESOLVER] →
+   - If player has red tile: `pending_sub_step = AWAITING_RED_TILE_DECISION`, `current_actor = PLAYER`
+   - Otherwise: compute outcome (lira gain), proceed to phase 4
+3. `RedTileDecision(use, ...)` [PLAYER] →
+   - `use=False`: compute outcome, proceed to phase 4
+   - `use=True, method=TO_FOUR`: apply deterministic die modification, compute outcome, proceed to phase 4
+   - `use=True, method=REROLL`: `pending_sub_step = AWAITING_SECOND_DICE_ROLL`, `current_actor = RESOLVER`
+4. `DiceRoll(result)` [RESOLVER] (only on REROLL) → compute outcome, proceed to phase 4
+
+**Black Market:** identical pattern to Tea House with `BlackMarketGoodChoice` at step 1.
+
+**Market:**
+1. `MarketGoodsChoice(goods)` [PLAYER] → `pending_sub_step = AWAITING_DEMAND_DRAW`, `current_actor = RESOLVER`
+2. `DemandDraw(demand)` [RESOLVER] → apply trade and set new demand, proceed to phase 4
+
+**Governor / Smuggler encounters:**
+1. `EncounterGovernorIntent(gain, cost)` [PLAYER] → `pending_sub_step = AWAITING_DICE_ROLL`, `current_actor = RESOLVER`
+2. `DiceRoll(result)` [RESOLVER] → move NPC to rolled location, complete encounter
+(No red tile involvement; the roll determines NPC movement only.)
+
+**Police station:**
+1. `SendFamilyMember(location)` [PLAYER] → validate preconditions, move family member,
+   set `dispatched_location = location`, remain in phase 3
+2. Player takes the appropriate tile action at `dispatched_location` (including any
+   sub-steps for that tile, e.g., if the destination is the Tea House)
+3. After the tile action and all its sub-steps complete, `dispatched_location` is cleared
+   and the turn proceeds to phase 4
+
+`dispatched_location` replaces the `family_member_acting` flag and the temporary player
+relocation entirely. Handlers that currently read `player_state.location` to determine
+the operating tile instead read `turn_state.dispatched_location or player_state.location`.
+
+### Randomness resolver
+
+The resolver is a runner-layer concept, not an engine concept. The engine accepts
+`DiceRoll` and `DemandDraw` actions via `take_action()` when `current_actor == RESOLVER`;
+it does not care who generated them.
 
 ```python
-def _handle_police_station_action(self, action: PoliceStationAction) -> None:
-    # validate and move family member ...
-    self.family_member_acting = True
-    self._execute_tile_action_at(action.action, action.location)
-    self.family_member_acting = False
-    # no player relocation needed
+class RandomnessResolver(Protocol):
+    def resolve_dice(self) -> tuple[int, int]: ...
+    def resolve_demand(self) -> Counter[Good]: ...
 ```
 
-**Main take_action phase 3 dispatch becomes:**
+Three implementations:
+- `ProgramResolver` — generates random values; **default**, most convenient for physical play
+- `HumanResolver` — prompts the operator for each value (physical dice, deck draws)
+- `ReplayResolver` — reads pre-recorded values from a sequence (for replaying old games)
 
-```python
-# instead of the current generic_action_map + match block:
-self._execute_tile_action_at(action, self.current_player_location)
-self._encounter_family_members()
-```
+### Replay format migration
 
-This phase 0 refactor should be covered by existing tests (behaviour is unchanged).
+The new action sequences are not backward-compatible with the existing CSV/JSON replay
+format, which records compound actions atomically. A conversion shim can be written when
+needed: each old compound action maps to a deterministic sequence of new actions:
+
+| Old action | New sequence |
+|-----------|-------------|
+| `TeaHouseAction(call, (a,b))` | `TeaHouseCall(call)`, `DiceRoll((a,b))`, `RedTileDecision(use=False)` |
+| `TeaHouseAction(call, RedTileAction(i, f, TO_FOUR))` | `TeaHouseCall(call)`, `DiceRoll(i)`, `RedTileDecision(use=True, TO_FOUR, ...)` |
+| `TeaHouseAction(call, RedTileAction(i, f, REROLL))` | `TeaHouseCall(call)`, `DiceRoll(i)`, `RedTileDecision(use=True, REROLL)`, `DiceRoll(f)` |
+| `BlackMarketAction(good, roll)` | analogous to Tea House |
+| `MarketAction(goods, demand)` | `MarketGoodsChoice(goods)`, `DemandDraw(demand)` |
+| `EncounterGovernor(gain, cost, roll)` | `EncounterGovernorIntent(gain, cost)`, `DiceRoll(roll)` |
+| `EncounterSmuggler(gain, cost, roll)` | `EncounterSmugglerIntent(gain, cost)`, `DiceRoll(roll)` |
+| `PoliceStationAction(loc, sub)` | `SendFamilyMember(loc)`, then converted `sub` |
+
+The shim does not need to be built now; it can be deferred until there are old replays
+that need to be preserved.
 
 ---
 
 ## Phase 1: Pure Validator — `is_valid_action`
 
-### Structure
-
 Add `GameState.is_valid_action(action: PlayerAction) -> bool` as a pure predicate.
-It never raises and never mutates state. `take_action()` keeps its existing behaviour
-(assert-on-invalid) but gates on `is_valid_action()` rather than inline assertions.
+It never raises and never mutates state. `take_action()` keeps its existing
+assert-on-invalid behaviour but gates on `is_valid_action()`.
 
-The validator has two layers, mirroring the existing two-level validation:
-
-1. **Phase/type check** — delegates to `TurnState.valid_action()` (already exists).
-2. **State check** — for each action type, check the preconditions that the handler
-   currently asserts.
+`legal_actions()` returns actions for `current_actor`: player actions when
+`current_actor == PLAYER`, resolver actions when `current_actor == RESOLVER`.
+The validator enforces this: a `DiceRoll` is invalid when `current_actor == PLAYER`
+and vice versa.
 
 ### Preconditions by action type
 
 **Cross-cutting:**
-- `ChooseReward`: `outstanding_reward_choices > 0`; choice is LIRA or a valid Card
-- `YieldTurn`: phase in {2, 4} and `outstanding_reward_choices == 0`
-- All others: `not completed`
+- `ChooseReward`: `outstanding_reward_choices > 0`; valid choice value
+- `YieldTurn`: phase in {2, 4}; `outstanding_reward_choices == 0`; `pending_sub_step is None`
+- All player actions: `current_actor == PLAYER`
 
-**Phase 1 actions:**
+**Phase 1:**
 - `Move(loc, skip)`: `taxicab_dist(current, loc) in {1, 2}`
 - `ExtraMoveCardAction(move)`: has EXTRA_MOVE card; `taxicab_dist(current, move.tile) in {3, 4}`
 - `NoMoveCardAction`: has NO_MOVE card
-- `ReturnAssistantCardAction(from_tile)`: has RETURN_ASSISTANT card; player has assistant at `from_tile`
-- `OneGoodCardAction(good)`: has ONE_GOOD card
-- `FiveLiraCardAction`: has FIVE_LIRA card
-- `ArrestFamilyCardAction(reward)`: has ARREST_FAMILY card; family not at police station
-- `YellowTileAction(from_tile)`: has YELLOW tile; has assistant at `from_tile`; lira >= 2
+- `ReturnAssistantCardAction(from_tile)`: has RETURN_ASSISTANT card; assistant at `from_tile`
+- `OneGoodCardAction`, `FiveLiraCardAction`, `ArrestFamilyCardAction`, `YellowTileAction`: card/tile held, other standard preconditions
 
-**Phase 2 actions:**
-- `Pay`: other players at current tile; lira >= (players_at_tile - 1) * 2
+**Phase 2:** `Pay`: other players at tile; lira >= (count − 1) × 2
 
-**Phase 3 tile actions** (all also require being at the right tile):
+**Phase 3 tile actions** (effective tile = `dispatched_location or current_player_location`):
 
 | Action | Key preconditions |
 |--------|------------------|
-| `GenericTileAction` at POST_OFFICE | at Post Office (always succeeds) |
-| `GenericTileAction` at warehouses | at correct warehouse |
-| `GenericTileAction` at WAINWRIGHT | lira >= 7; cart_max < 5; extensions remaining |
-| `GenericTileAction` at GEMSTONE_DEALER | `dealer_state.cost is not None`; lira >= cost |
-| `GenericTileAction` at FOUNTAIN | at Fountain |
-| `FountainAction(locs)` | at Fountain; `locs ⊆ player.assistant_locations`; `locs` non-empty |
-| `MosqueAction(good)` | at mosque; player lacks that tile; mosque has that tile available; player has enough goods |
-| `BlackMarketAction(good, roll)` | at Black Market; if RedTileAction roll: has red tile; roll sentinel accepted |
-| `CaravansaryAction(gains, cost)` | at Caravansary; has `cost` card; discard pile depth >= count of DISCARD gains; not awaiting_discard |
-| `MarketAction(goods, new_demand)` | at Small or Large Market; player has those goods; goods ≤ demand for each type; not expecting_demand; new_demand sentinel accepted |
-| `TeaHouseAction(call, roll)` | at Tea House; call in {3..12}; if RedTileAction roll: has red tile; roll sentinel accepted |
-| `SultansPalaceAction(goods)` | at Sultan's Palace; `required()` not None; goods satisfies required count and per-good minimums |
-| `PoliceStationAction(location, sub)` | at Police Station; player has family at police station; location != police_station; `_can_do_tile_action_at(sub, location)` |
+| `GenericTileAction` | at correct tile for that action; resource checks (lira, extensions) as applicable |
+| `FountainAction(locs)` | at Fountain; `locs ⊆ assistant_locations`; non-empty |
+| `MosqueAction(good)` | at mosque; player lacks tile; mosque offers it; has goods to pay |
+| `BlackMarketGoodChoice(good)` | at Black Market |
+| `CaravansaryAction(gains, cost)` | at Caravansary; has cost card; discard depth ≥ DISCARD count; not awaiting_discard |
+| `MarketGoodsChoice(goods)` | at Small or Large Market; has those goods; within demand; not expecting_demand |
+| `TeaHouseCall(call)` | at Tea House; call in {3..12} |
+| `SultansPalaceAction(goods)` | at Sultan's Palace; `required()` not None; goods satisfies requirement |
+| `SendFamilyMember(location)` | at Police Station; player has family there; location ≠ police station |
 | `SkipTileAction` | always valid in phase 3 |
-| `GreenTileAction(good)` | has GREEN tile; at a warehouse tile; lira >= 2 |
-| `SellAnyCardAction(market_action)` | has SELL_ANY card; at SMALL_MARKET; market_action valid at that tile |
-| `DoubleCardAction(card, actions)` | has the card; at the right tile; each sub-action independently valid at that tile |
+| `GreenTileAction(good)` | has GREEN tile; at warehouse; lira >= 2 |
+| `SellAnyCardAction(action)` | has SELL_ANY card; at SMALL_MARKET; inner action valid |
+| `DoubleCardAction(card, actions)` | has card; at correct tile; each sub-action valid |
 
-**Phase 4 actions:**
-- `EncounterGovernor(gain, cost, roll)`: governor at current tile; if cost is Pay: lira >= 2; if cost is Card: has that card; roll sentinel accepted
-- `EncounterSmuggler(gain, cost, roll)`: smuggler at current tile; if cost is Pay: lira >= 2; if cost is Good: has that good in cart; roll sentinel accepted
+**Phase 4:**
+- `EncounterGovernorIntent(gain, cost)`: governor at tile; can pay cost
+- `EncounterSmugglerIntent(gain, cost)`: smuggler at tile; can pay cost
+
+**Resolver actions:**
+- `DiceRoll(result)`: `current_actor == RESOLVER`; `pending_sub_step in {AWAITING_DICE_ROLL, AWAITING_SECOND_DICE_ROLL}`; result is a valid 2d6 tuple
+- `DemandDraw(demand)`: `current_actor == RESOLVER`; `pending_sub_step == AWAITING_DEMAND_DRAW`; demand sums to 5
+
+**Sub-step actions:**
+- `RedTileDecision(use=False)`: `pending_sub_step == AWAITING_RED_TILE_DECISION`
+- `RedTileDecision(use=True, ...)`: additionally, player has red tile; modification is valid for the recorded initial roll
 
 ### Implementation note
 
-`_can_do_tile_action_at(action, location) -> bool` is a private helper that performs
-phase 3 validation at an arbitrary location (used both by the main validator and by the
-PoliceStationAction validator for its sub-action). It directly mirrors
-`_execute_tile_action_at` in structure.
-
-Because a police station sub-action can itself be a dice-bearing action (e.g.,
-`TeaHouseAction(call, UNRESOLVED_ROLL)` sent via the police station), `_can_do_tile_action_at`
-must apply the same sentinel-skipping logic as the top-level validator — it must accept
-sentinel values in roll and demand parameters without treating them as invalid.
+`_can_do_tile_action_at(action, location) -> bool` is a private helper performing phase 3
+validation at an arbitrary location — used by the main validator (passing
+`dispatched_location or current_player_location`) and directly for validating tile actions
+during a police station dispatch without any player relocation.
 
 ---
 
@@ -157,145 +247,100 @@ sentinel values in roll and demand parameters without treating them as invalid.
 
 `legal_actions()` = filter(`is_valid_action`, `_candidate_actions()`).
 
-`_candidate_actions()` generates a superset of plausible actions for the current
-phase, without worrying about whether all of them pass validation. The validator is
-the source of correctness; the generator just needs to cover all possibilities.
+Because player actions no longer contain random outcomes, no sentinel values appear in
+the player action candidates. Resolver action candidates (`DiceRoll`, `DemandDraw`) are
+generated separately when `current_actor == RESOLVER`.
 
-### Sentinel strategy
+### By phase / sub-step
 
-Sentinel values are used **only** for parameters that are resolved by external physical
-mechanisms (dice rolls, demand card draws from the physical deck). Everything else —
-including goods combinations at Sultan's Palace, fountain recall subsets, and market
-goods selections — is enumerated in full. This keeps the legal_actions list concrete and
-complete, allowing the LLM to make informed strategic choices across all dimensions of
-each action.
+**Phase 1:** `Move`, `ExtraMoveCardAction`, `NoMoveCardAction`, `ReturnAssistantCardAction`
+for all applicable locations; phase-all cards.
 
-A module-level `UNRESOLVED_ROLL` and `UNRESOLVED_DEMAND` constant (typed appropriately)
-should be defined before implementation. The validator accepts these in roll and demand
-parameter positions without performing the specific-value checks that apply to real values.
+**Phase 2:** `YieldTurn`, `Pay`, phase-all cards.
 
-| Sentinel | Used in | Who resolves it |
-|----------|---------|-----------------|
-| `UNRESOLVED_ROLL` | `TeaHouseAction.roll`, `BlackMarketAction.roll`, `EncounterGovernor.roll`, `EncounterSmuggler.roll` | Game runner after LLM picks intent |
-| `UNRESOLVED_DEMAND` | `MarketAction.new_demand` | Game runner draws demand card after trade |
+**Phase 3 tile candidates:**
 
-### By phase
+| Tile | Candidates |
+|------|-----------|
+| POST_OFFICE, warehouses, WAINWRIGHT, GEMSTONE_DEALER | `GenericTileAction()` |
+| FOUNTAIN | `GenericTileAction()` (recall all); `FountainAction(subset)` for each non-empty proper subset of `assistant_locations` (≤ 31) |
+| GREAT / SMALL MOSQUE | `MosqueAction(good)` for each available good |
+| BLACK_MARKET | `BlackMarketGoodChoice(good)` for each of {RED, GREEN, YELLOW} |
+| CARAVANSARY | `CaravansaryAction(gains, cost)` for each card in hand × valid gain combination |
+| SMALL / LARGE MARKET | `MarketGoodsChoice(goods)` for each non-empty subset of (cart ∩ demand) |
+| TEA_HOUSE | `TeaHouseCall(call)` for call in {3..12} |
+| SULTANS_PALACE | `SultansPalaceAction(goods)` for each valid `Counter[Good]` satisfying `required()` |
+| POLICE_STATION | `SendFamilyMember(location)` for each non-police-station location |
 
-**Phase 1:**
-- `Move(loc, skip)` for all 16 locations × {True, False}
-- If has EXTRA_MOVE: `ExtraMoveCardAction(Move(loc, skip))` for all 16 × {True, False}
-- If has NO_MOVE: `NoMoveCardAction(True)`, `NoMoveCardAction(False)`
-- If has RETURN_ASSISTANT: `ReturnAssistantCardAction(loc)` for each location in `assistant_locations`
-- Phase-all cards (see below)
-- If `yield_required`: only phase-all cards + `YieldTurn()`
+**Phase 3 card candidates:** `GreenTileAction`, `SellAnyCardAction`, `DoubleCardAction`
+as before.
 
-**Phase 2:**
-- `YieldTurn()`
-- `Pay()`
-- Phase-all cards
+**Phase 4:** `EncounterGovernorIntent(gain, cost)` for each Card gain × each (Card in
+hand + Pay) as cost; analogously for smuggler; `ChooseReward` if outstanding; `YieldTurn`.
 
-**Phase 3:**
-- `SkipTileAction()`
-- Tile-specific candidates for current tile (see tile generators below)
-- Phase-all cards
-- If at a warehouse and has GREEN tile: `GreenTileAction(good)` for each Good (except BLUE)
-- If has SELL_ANY and at SMALL_MARKET: `SellAnyCardAction(action)` for each valid market candidate
-- If has DOUBLE_SULTAN and at SULTANS_PALACE: `DoubleCardAction(DOUBLE_SULTAN, (a, a))` for valid palace action `a`
-- If has DOUBLE_PO and at POST_OFFICE: `DoubleCardAction(DOUBLE_PO, (GenericTileAction(), GenericTileAction()))`
-- If has DOUBLE_DEALER and at GEMSTONE_DEALER: `DoubleCardAction(DOUBLE_DEALER, (GenericTileAction(), GenericTileAction()))`
+**Sub-step candidates:**
+- `AWAITING_DICE_ROLL` / `AWAITING_SECOND_DICE_ROLL`: `DiceRoll(result)` for all valid
+  2d6 results (for testing/human input) — in practice the resolver generates one value
+- `AWAITING_RED_TILE_DECISION`: `RedTileDecision(use=False)`; if player has red tile,
+  also `RedTileDecision(use=True, TO_FOUR, die=0)`, `RedTileDecision(use=True, TO_FOUR, die=1)`,
+  `RedTileDecision(use=True, REROLL)`
+- `AWAITING_DEMAND_DRAW`: `DemandDraw(demand)` for any valid demand counter
 
-**Phase 4 / outstanding rewards:**
-- If `outstanding_reward_choices > 0`: `ChooseReward(LIRA)` + `ChooseReward(card)` for each Card
-- If governor at tile: `EncounterGovernor(gain, cost, UNRESOLVED_ROLL)` for each `Card` gain × each (Card in hand + `Pay`) as cost
-- If smuggler at tile: `EncounterSmuggler(gain, cost, UNRESOLVED_ROLL)` for each `Good` gain × each (Good with > 0 in cart + `Pay`) as cost
-- `YieldTurn()`
-- Phase-all cards
-
-**Phase-all cards** (valid in phases 1, 2, 3, 4 when yield_required or not):
-- If has ONE_GOOD: `OneGoodCardAction(good)` for each Good
-- If has FIVE_LIRA: `FiveLiraCardAction()`
-- If has ARREST_FAMILY: `ArrestFamilyCardAction(ChooseReward(choice))` for each choice
-- If has YELLOW tile: `YellowTileAction(loc)` for each location in `assistant_locations`
-
-### Tile-specific candidate generators
-
-| Tile | Candidates generated |
-|------|---------------------|
-| POST_OFFICE | `GenericTileAction()` |
-| FABRIC / SPICE / FRUIT WAREHOUSE | `GenericTileAction()` |
-| WAINWRIGHT | `GenericTileAction()` |
-| FOUNTAIN | `GenericTileAction()` (recall all); `FountainAction(subset)` for each non-empty proper subset of `assistant_locations` (up to 2^5 − 1 = 31 subsets; tractable) |
-| GEMSTONE_DEALER | `GenericTileAction()` |
-| GREAT_MOSQUE / SMALL_MOSQUE | `MosqueAction(good)` for each Good available at that mosque |
-| BLACK_MARKET | `BlackMarketAction(good, UNRESOLVED_ROLL)` for each of {RED, GREEN, YELLOW} |
-| CARAVANSARY | `CaravansaryAction(gains, cost)` for each card in hand as cost, each valid gain combination |
-| SMALL_MARKET / LARGE_MARKET | `MarketAction(goods, UNRESOLVED_DEMAND)` for each non-empty subset of (player goods ∩ demand) |
-| TEA_HOUSE | `TeaHouseAction(call, UNRESOLVED_ROLL)` for call in {3..12} |
-| SULTANS_PALACE | `SultansPalaceAction(goods)` for each valid `Counter[Good]` satisfying `required()` given player's cart contents (see note) |
-| POLICE_STATION | `PoliceStationAction(loc, sub)` for each non-police-station location × each valid sub-action candidate at that tile |
-
-**Sultan's Palace goods enumeration:** When `required()` contains `None` wildcard slots,
-multiple goods combinations are valid (any good can fill a wildcard). With 4 good types,
-a cart max of 5 per good, and a small number of wildcards (the count grows slowly as
-`required_count` increases), the set of valid combinations is tractable. Enumerate all
-`Counter[Good]` that satisfy: total count equals `required_count`; for each specific Good
-`g` in `required()`, counter includes at least `required[g]` of `g`; for each Good `g`,
-counter does not exceed `cart_contents[g]`.
-
-### Dice and red tile sequencing (open design question)
-
-Several actions encode both a player intent and a random dice outcome in a single
-object: `TeaHouseAction(call, roll)`, `BlackMarketAction(good, roll)`. The sentinel
-approach handles the common case: the LLM picks the intent, dice are rolled externally,
-the runner constructs the final action.
-
-The complication arises when the player has the **red tile**: after seeing the dice
-result, the player may modify one die (set to 4) or reroll both. This decision is
-strategically dependent on the actual roll, so it cannot be made at the same time as
-the intent. The options are:
-
-1. **Two-query protocol:** LLM picks intent (`TeaHouseAction(call=7, UNRESOLVED_ROLL)`),
-   runner resolves dice, runner re-queries the LLM with the dice result and asks whether
-   to use the red tile. The engine still receives a single atomic action; the splitting
-   is at the runner/integration layer only. No changes to action types or JSON schema.
-
-2. **Upfront red tile declaration:** LLM is asked to commit to both the intent and red
-   tile usage before dice are rolled (e.g., "I'll call 7 and use red tile to set-to-4 if
-   I roll below 4 on either die"). The runner resolves this rule-based. Simpler runner,
-   but requires specifying a conditional rather than a direct choice, which may be
-   awkward for the LLM.
-
-3. **Intermediate engine actions:** Split `TeaHouseAction` into a call-action and a
-   separate optional roll-modification action. Cleaner conceptually but requires changes
-   to action types, the JSON schema, and the existing runner/replay machinery.
-
-Option 1 is the path of least resistance and preserves all existing engine behaviour.
-Option 3 is the cleanest long-term design but has significant scope. **This choice must
-be made before Phase 2 implementation begins** since it affects the action types used
-in candidate generation.
+**Sultan's Palace goods:** Enumerate all `Counter[Good]` satisfying `required()` given
+cart contents — tractable with 4 good types and slowly-growing wildcard count.
 
 ---
 
-## Phase 3: Public API and Game State Observation
+## Phase 3: JSON Interface Module
 
-### `legal_actions() -> list[PlayerAction]`
+### Module: `istanbul_game/interface.py`
+
+A pure translation layer with no game logic. Takes Python action/state objects from the
+engine; returns JSON-serialisable dicts. Has no imports from the runner layer.
+
+Primary functions:
 
 ```python
-def legal_actions(self) -> list[PlayerAction]:
-    """Return all legal actions available to the current player right now."""
-    return [a for a in self._candidate_actions() if self.is_valid_action(a)]
+def legal_actions_json(actions: list[PlayerAction]) -> list[dict]: ...
+def game_state_json(gs: GameState) -> dict: ...
+def action_from_json(data: dict) -> PlayerAction: ...
+def action_guide_markdown() -> str: ...
 ```
 
-### Game state description — `describe()`
+### Action representation — tool-call format
 
-Add `GameState.describe() -> dict` producing a structured snapshot of the current state.
-The format should be serialisable (JSON-compatible) and complete enough that an LLM can
-reason about strategy without access to any other state.
+Each legal action is a JSON object with `name` and `args`:
 
-**Fields:**
+```json
+{"name": "TeaHouseCall", "args": {"call": 7}}
+{"name": "MarketGoodsChoice", "args": {"goods": {"red": 1, "green": 2}}}
+{"name": "SendFamilyMember", "args": {"location": 5}}
+{"name": "DiceRoll", "args": {"result": [3, 4]}}
+```
+
+When multiple actions have the same `name` but differ only in one independent parameter
+dimension, the interface module **may** collapse them into a Cartesian product form if
+it reduces noise without losing information:
+
+```json
+{
+  "name": "TeaHouseCall",
+  "args": {"call": {"type": "int", "range": [3, 12]}}
+}
+```
+
+This is a display optimisation; `action_from_json` always accepts both the explicit and
+collapsed forms. Whether to collapse a given action type is decided per-type at
+implementation time. Good candidates: `TeaHouseCall` (call range), `Move` (destination
+grid), `EncounterGovernorIntent` (gain × cost grid). Poor candidates: `MarketGoodsChoice`
+(interdependent goods constraints), `SultansPalaceAction` (goods constrained by cart).
+
+### Game state description — `game_state_json()`
+
 ```
 current_player:
-  color, phase, lira, rubies
+  color, phase, pending_sub_step, current_actor
+  lira, rubies
   cart: {red, blue, green, yellow, cart_max}
   hand: {card_name: count, ...}
   assistant_locations: [location_numbers]
@@ -304,65 +349,68 @@ current_player:
 other_players: [{color, location, rubies}, ...]   # public info only
 
 board:
-  governor_location: location_number
-  smuggler_location: location_number
+  governor_location, smuggler_location
   tile_layout: {location_number: tile_name, ...}
 
 tiles:
   small_market: {demand: {good: count}, one_cost: int}
   large_market: {demand: {good: count}, one_cost: int}
   post_office: {position: int, next_goods: [good_names], next_lira: int}
-  great_mosque: {available_tiles: {good: cost}, ...}
-  small_mosque: {available_tiles: {good: cost}, ...}
-  sultans_palace: {required_count: int, required: {good: count}}
+  great_mosque: {available_tiles: {good: cost}}
+  small_mosque: {available_tiles: {good: cost}}
+  sultans_palace: {required_count: int, required: {good_or_any: count}}
   gemstone_dealer: {cost: int | null}
   wainwright: {extensions_remaining: int}
-  caravansary: {discard_pile_top: card_name | null}
+  caravansary: {discard_pile_depth: int, discard_pile_top: card_name | null}
 
 outstanding_reward_choices: int
 ```
 
-### LLM prompt guide
+### Action guide
 
-In addition to `describe()`, the integration layer should provide a static markdown
-explanation of the action format and sentinel values as part of the system prompt or
-alongside the legal actions list. At minimum it should explain:
+`action_guide_markdown()` returns a static markdown document (suitable for inclusion in
+an LLM system prompt) explaining:
 
-- What `UNRESOLVED_ROLL` means and that the runner will prompt for the dice result
-- What `UNRESOLVED_DEMAND` means and that the new demand will be input after the trade
-- How to interpret `FountainAction(locations)` vs `GenericTileAction()` at the Fountain
-- The two-step resolution protocol for red tile decisions (once that is resolved above)
+- The turn structure (phases, sub-steps)
+- Each action name, its arguments, and when it is available
+- What resolver actions are (`DiceRoll`, `DemandDraw`) and that the runner provides them
+  automatically when using `ProgramResolver`
+- How `RedTileDecision` works and when it appears
+- How to request per-action documentation or evaluate a specific action call
 
-The legal actions list itself may also be offered as full enumeration on request — if
-the LLM's response does not match a legal action, the runner can re-query with the
-explicit list rather than failing immediately.
+The LLM may also request a full explicit enumeration of legal actions if the compact
+form is ambiguous — the runner should support a re-query that provides the expanded list.
 
 ---
 
 ## Testing
 
-All phases must be covered by tests:
-
-- **Phase 0:** Existing tests should pass unchanged after refactor.
-- **Phase 1:** Unit tests for `is_valid_action` covering valid and invalid cases for each
-  action type. Verify that `is_valid_action` agrees with `take_action` (no action that
-  passes the validator should raise when taken, and vice versa) — a property test is
-  well-suited here.
-- **Phase 2:** `legal_actions()` is tested against known game states, verifying no legal
-  action is omitted and no illegal action is included.
-- **Phase 3:** `describe()` is a snapshot test.
+- **Phase 0:** All existing tests pass unchanged (observable behaviour is identical).
+  New tests cover each sub-step sequence end-to-end (Tea House, Black Market, Market,
+  Governor, Smuggler, Police Station dispatch) using each resolver type.
+- **Phase 1:** Unit tests for `is_valid_action` covering valid and invalid cases for
+  each action type and sub-step state. Property test: no action returned by
+  `legal_actions()` raises when passed to `take_action()`, and no action that does not
+  raise in `take_action()` is absent from `legal_actions()`.
+- **Phase 2:** `legal_actions()` tested against known game states; no legal action
+  omitted, no illegal action included. Separate tests for resolver action candidates.
+- **Phase 3:** `game_state_json()` and `legal_actions_json()` snapshot tests.
+  Round-trip test: `action_from_json(legal_actions_json([a])[0]) == a` for all action types.
 
 ---
 
 ## File layout
 
-New code belongs in the `istanbul_game` package:
-
 | File | Contents |
 |------|----------|
-| `istanbul_game/game.py` | `is_valid_action`, `_can_do_tile_action_at`, `_execute_tile_action_at`, `_candidate_actions`, `legal_actions`, `describe`; refactored handlers |
-| `istanbul_game/candidates.py` | Candidate generator helpers (if game.py becomes unwieldy) |
-| `tests/test_validator.py` | Validator unit tests |
-| `tests/test_legal_actions.py` | Legal actions integration tests |
-
-The phase 0 police station refactor stays entirely within `game.py`.
+| `istanbul_game/actions.py` | New decomposed action types alongside retained types; old compound types removed or kept in `actions_legacy.py` for shim use |
+| `istanbul_game/turn.py` | `TurnState` extended with `current_actor`, `pending_sub_step`, `dispatched_location` |
+| `istanbul_game/game.py` | `is_valid_action`, `_can_do_tile_action_at`, `_candidate_actions`, `legal_actions`; refactored handlers reading from execution context |
+| `istanbul_game/resolver.py` | `RandomnessResolver` protocol; `ProgramResolver`, `HumanResolver`, `ReplayResolver` |
+| `istanbul_game/interface.py` | `legal_actions_json`, `game_state_json`, `action_from_json`, `action_guide_markdown` |
+| `istanbul_game/candidates.py` | Candidate generator helpers if `game.py` becomes unwieldy |
+| `istanbul_game/shim.py` | Replay format conversion (deferred; implement when needed) |
+| `tests/test_substeps.py` | Sub-step sequence tests |
+| `tests/test_validator.py` | `is_valid_action` unit tests |
+| `tests/test_legal_actions.py` | `legal_actions()` integration tests |
+| `tests/test_interface.py` | JSON round-trip and snapshot tests |

--- a/designs/DESIGN-LLM-PLAYER.md
+++ b/designs/DESIGN-LLM-PLAYER.md
@@ -4,12 +4,11 @@
 > engine through three sequential phases: a prerequisite refactor to eliminate the police
 > station temporary-relocation hack, extraction of a pure `is_valid_action()` predicate,
 > and implementation of candidate generators feeding a `legal_actions()` API plus a
-> `describe()` state snapshot. Several action types encode parameters that are either
-> resolved externally (dice rolls, market demand draws) or represent open choices too
-> numerous to enumerate (fountain recall subsets, sultan's palace wildcard goods); a
-> consistent sentinel value strategy for these needs to be agreed on before implementation
-> begins, as it touches both the action data model and the game runner flow. No other
-> external decisions are needed to start Phase 0.
+> `describe()` state snapshot. Sentinel values are used only for genuinely random
+> externally-resolved parameters (dice rolls, demand card draws); all other parameters
+> are enumerated in full. One open design question must be resolved before Phase 2
+> implementation: the multi-step interaction protocol for dice-dependent red tile
+> decisions at the Tea House and Black Market (see "Dice and red tile sequencing" below).
 
 This document describes the plan for enabling an LLM to act as one or more players
 in the Istanbul game engine. The approach is to expose a `legal_actions()` API that
@@ -123,13 +122,13 @@ The validator has two layers, mirroring the existing two-level validation:
 | `GenericTileAction` at WAINWRIGHT | lira >= 7; cart_max < 5; extensions remaining |
 | `GenericTileAction` at GEMSTONE_DEALER | `dealer_state.cost is not None`; lira >= cost |
 | `GenericTileAction` at FOUNTAIN | at Fountain |
+| `FountainAction(locs)` | at Fountain; `locs ⊆ player.assistant_locations`; `locs` non-empty |
 | `MosqueAction(good)` | at mosque; player lacks that tile; mosque has that tile available; player has enough goods |
-| `BlackMarketAction(good, roll)` | at Black Market; if RedTileAction roll: has red tile |
+| `BlackMarketAction(good, roll)` | at Black Market; if RedTileAction roll: has red tile; roll sentinel accepted |
 | `CaravansaryAction(gains, cost)` | at Caravansary; has `cost` card; discard pile depth >= count of DISCARD gains; not awaiting_discard |
-| `MarketAction(goods, new_demand)` | at Small or Large Market; player has those goods; goods ≤ demand for each type; not expecting_demand |
-| `TeaHouseAction(call, roll)` | at Tea House; call in {3..12}; if RedTileAction roll: has red tile |
-| `SultansPalaceAction(goods)` | at Sultan's Palace; `required()` not None; player has enough goods matching requirement |
-| `FountainAction(locs)` | at Fountain; `locs ⊆ player.assistant_locations` |
+| `MarketAction(goods, new_demand)` | at Small or Large Market; player has those goods; goods ≤ demand for each type; not expecting_demand; new_demand sentinel accepted |
+| `TeaHouseAction(call, roll)` | at Tea House; call in {3..12}; if RedTileAction roll: has red tile; roll sentinel accepted |
+| `SultansPalaceAction(goods)` | at Sultan's Palace; `required()` not None; goods satisfies required count and per-good minimums |
 | `PoliceStationAction(location, sub)` | at Police Station; player has family at police station; location != police_station; `_can_do_tile_action_at(sub, location)` |
 | `SkipTileAction` | always valid in phase 3 |
 | `GreenTileAction(good)` | has GREEN tile; at a warehouse tile; lira >= 2 |
@@ -137,15 +136,20 @@ The validator has two layers, mirroring the existing two-level validation:
 | `DoubleCardAction(card, actions)` | has the card; at the right tile; each sub-action independently valid at that tile |
 
 **Phase 4 actions:**
-- `EncounterGovernor(gain, cost, roll)`: governor at current tile; if cost is Pay: lira >= 2; if cost is Card: has that card
-- `EncounterSmuggler(gain, cost, roll)`: smuggler at current tile; if cost is Pay: lira >= 2; if cost is Good: has that good in cart
+- `EncounterGovernor(gain, cost, roll)`: governor at current tile; if cost is Pay: lira >= 2; if cost is Card: has that card; roll sentinel accepted
+- `EncounterSmuggler(gain, cost, roll)`: smuggler at current tile; if cost is Pay: lira >= 2; if cost is Good: has that good in cart; roll sentinel accepted
 
 ### Implementation note
 
 `_can_do_tile_action_at(action, location) -> bool` is a private helper that performs
 phase 3 validation at an arbitrary location (used both by the main validator and by the
-PoliceStationAction validator for its sub-action). This directly mirrors
+PoliceStationAction validator for its sub-action). It directly mirrors
 `_execute_tile_action_at` in structure.
+
+Because a police station sub-action can itself be a dice-bearing action (e.g.,
+`TeaHouseAction(call, UNRESOLVED_ROLL)` sent via the police station), `_can_do_tile_action_at`
+must apply the same sentinel-skipping logic as the top-level validator — it must accept
+sentinel values in roll and demand parameters without treating them as invalid.
 
 ---
 
@@ -156,6 +160,24 @@ PoliceStationAction validator for its sub-action). This directly mirrors
 `_candidate_actions()` generates a superset of plausible actions for the current
 phase, without worrying about whether all of them pass validation. The validator is
 the source of correctness; the generator just needs to cover all possibilities.
+
+### Sentinel strategy
+
+Sentinel values are used **only** for parameters that are resolved by external physical
+mechanisms (dice rolls, demand card draws from the physical deck). Everything else —
+including goods combinations at Sultan's Palace, fountain recall subsets, and market
+goods selections — is enumerated in full. This keeps the legal_actions list concrete and
+complete, allowing the LLM to make informed strategic choices across all dimensions of
+each action.
+
+A module-level `UNRESOLVED_ROLL` and `UNRESOLVED_DEMAND` constant (typed appropriately)
+should be defined before implementation. The validator accepts these in roll and demand
+parameter positions without performing the specific-value checks that apply to real values.
+
+| Sentinel | Used in | Who resolves it |
+|----------|---------|-----------------|
+| `UNRESOLVED_ROLL` | `TeaHouseAction.roll`, `BlackMarketAction.roll`, `EncounterGovernor.roll`, `EncounterSmuggler.roll` | Game runner after LLM picks intent |
+| `UNRESOLVED_DEMAND` | `MarketAction.new_demand` | Game runner draws demand card after trade |
 
 ### By phase
 
@@ -184,8 +206,8 @@ the source of correctness; the generator just needs to cover all possibilities.
 
 **Phase 4 / outstanding rewards:**
 - If `outstanding_reward_choices > 0`: `ChooseReward(LIRA)` + `ChooseReward(card)` for each Card
-- If governor at tile: `EncounterGovernor(...)` — see note on rolls below
-- If smuggler at tile: `EncounterSmuggler(...)` — see note on rolls below
+- If governor at tile: `EncounterGovernor(gain, cost, UNRESOLVED_ROLL)` for each `Card` gain × each (Card in hand + `Pay`) as cost
+- If smuggler at tile: `EncounterSmuggler(gain, cost, UNRESOLVED_ROLL)` for each `Good` gain × each (Good with > 0 in cart + `Pay`) as cost
 - `YieldTurn()`
 - Phase-all cards
 
@@ -202,54 +224,55 @@ the source of correctness; the generator just needs to cover all possibilities.
 | POST_OFFICE | `GenericTileAction()` |
 | FABRIC / SPICE / FRUIT WAREHOUSE | `GenericTileAction()` |
 | WAINWRIGHT | `GenericTileAction()` |
-| FOUNTAIN | `FountainAction(RECALL_ALL)` sentinel entry only (players can have up to 5 assistants in the field, making full subset enumeration impractical) |
+| FOUNTAIN | `GenericTileAction()` (recall all); `FountainAction(subset)` for each non-empty proper subset of `assistant_locations` (up to 2^5 − 1 = 31 subsets; tractable) |
 | GEMSTONE_DEALER | `GenericTileAction()` |
 | GREAT_MOSQUE / SMALL_MOSQUE | `MosqueAction(good)` for each Good available at that mosque |
-| BLACK_MARKET | `BlackMarketAction(good, roll)` for each of {RED, GREEN, YELLOW} — roll is a placeholder (see below) |
+| BLACK_MARKET | `BlackMarketAction(good, UNRESOLVED_ROLL)` for each of {RED, GREEN, YELLOW} |
 | CARAVANSARY | `CaravansaryAction(gains, cost)` for each card in hand as cost, each valid gain combination |
-| SMALL_MARKET / LARGE_MARKET | `MarketAction(goods, new_demand)` for each non-empty subset of (player goods ∩ demand) — `new_demand` is a placeholder (see below) |
-| TEA_HOUSE | `TeaHouseAction(call, roll)` for call in {3..12} — roll is a placeholder (see below) |
-| SULTANS_PALACE | `SultansPalaceAction(AUTO_GOODS)` sentinel entry (wildcard slots make enumerating valid combinations complex; runner resolves goods) |
+| SMALL_MARKET / LARGE_MARKET | `MarketAction(goods, UNRESOLVED_DEMAND)` for each non-empty subset of (player goods ∩ demand) |
+| TEA_HOUSE | `TeaHouseAction(call, UNRESOLVED_ROLL)` for call in {3..12} |
+| SULTANS_PALACE | `SultansPalaceAction(goods)` for each valid `Counter[Good]` satisfying `required()` given player's cart contents (see note) |
 | POLICE_STATION | `PoliceStationAction(loc, sub)` for each non-police-station location × each valid sub-action candidate at that tile |
 
-### Sentinel values for open or externally-resolved parameters
+**Sultan's Palace goods enumeration:** When `required()` contains `None` wildcard slots,
+multiple goods combinations are valid (any good can fill a wildcard). With 4 good types,
+a cart max of 5 per good, and a small number of wildcards (the count grows slowly as
+`required_count` increases), the set of valid combinations is tractable. Enumerate all
+`Counter[Good]` that satisfy: total count equals `required_count`; for each specific Good
+`g` in `required()`, counter includes at least `required[g]` of `g`; for each Good `g`,
+counter does not exceed `cart_contents[g]`.
 
-Several action types contain parameters that are either resolved by external game
-mechanics (dice, drawn cards) or represent choices that are too numerous to enumerate
-cleanly in a legal-actions list. For all of these the `legal_actions()` API uses a
-named sentinel value in place of the actual parameter. The validator treats any sentinel
-as vacuously valid for that parameter slot; the game runner fills in real values before
-calling `take_action()`.
+### Dice and red tile sequencing (open design question)
 
-A module-level `SENTINEL` marker (or per-field constants) should be defined before
-implementation begins so that all action types use a consistent approach.
+Several actions encode both a player intent and a random dice outcome in a single
+object: `TeaHouseAction(call, roll)`, `BlackMarketAction(good, roll)`. The sentinel
+approach handles the common case: the LLM picks the intent, dice are rolled externally,
+the runner constructs the final action.
 
-| Action | Sentinel parameter | Who resolves it |
-|--------|--------------------|-----------------|
-| `TeaHouseAction.roll` | `UNRESOLVED_ROLL` | Game runner rolls dice after LLM picks `call` |
-| `BlackMarketAction.roll` | `UNRESOLVED_ROLL` | Game runner rolls dice after LLM picks good |
-| `EncounterGovernor.roll` | `UNRESOLVED_ROLL` | Game runner rolls dice |
-| `EncounterSmuggler.roll` | `UNRESOLVED_ROLL` | Game runner rolls dice |
-| `MarketAction.new_demand` | `UNRESOLVED_DEMAND` | Game runner draws demand card after trade |
-| `FountainAction.assistant_locations` | `RECALL_ALL` | Validator/handler reads all player assistant locations |
-| `SultansPalaceAction.goods` | `AUTO_GOODS` | Game runner (or handler) picks any valid goods combination from player's cart |
+The complication arises when the player has the **red tile**: after seeing the dice
+result, the player may modify one die (set to 4) or reroll both. This decision is
+strategically dependent on the actual roll, so it cannot be made at the same time as
+the intent. The options are:
 
-**Fountain:** A player may have up to 5 assistants on the board (starting stack of 4,
-+1 from the Blue mosque tile), yielding up to 32 possible subset choices. Enumerating
-all subsets adds noise without benefit to the LLM. `legal_actions()` returns a single
-`FountainAction(RECALL_ALL)` sentinel entry; if partial recall is ever needed the LLM
-can request it via a separate mechanism.
+1. **Two-query protocol:** LLM picks intent (`TeaHouseAction(call=7, UNRESOLVED_ROLL)`),
+   runner resolves dice, runner re-queries the LLM with the dice result and asks whether
+   to use the red tile. The engine still receives a single atomic action; the splitting
+   is at the runner/integration layer only. No changes to action types or JSON schema.
 
-**Sultan's Palace wildcards:** When `required_count` exceeds 4 the requirement includes
-`None` wildcard slots (any good). The LLM does not need to reason about which specific
-good fills each wildcard; `AUTO_GOODS` signals the runner to pick any valid combination
-from the player's cart.
+2. **Upfront red tile declaration:** LLM is asked to commit to both the intent and red
+   tile usage before dice are rolled (e.g., "I'll call 7 and use red tile to set-to-4 if
+   I roll below 4 on either die"). The runner resolves this rule-based. Simpler runner,
+   but requires specifying a conditional rather than a direct choice, which may be
+   awkward for the LLM.
 
-**Validator behaviour:** The validator skips the specific-value checks for sentinel
-slots (e.g., roll validation, demand validation, goods-match validation) and only checks
-the non-sentinel preconditions (correct tile, sufficient resources, etc.). This must be
-documented clearly so future implementors do not accidentally tighten the validator
-to reject sentinels.
+3. **Intermediate engine actions:** Split `TeaHouseAction` into a call-action and a
+   separate optional roll-modification action. Cleaner conceptually but requires changes
+   to action types, the JSON schema, and the existing runner/replay machinery.
+
+Option 1 is the path of least resistance and preserves all existing engine behaviour.
+Option 3 is the cleanest long-term design but has significant scope. **This choice must
+be made before Phase 2 implementation begins** since it affects the action types used
+in candidate generation.
 
 ---
 
@@ -263,20 +286,56 @@ def legal_actions(self) -> list[PlayerAction]:
     return [a for a in self._candidate_actions() if self.is_valid_action(a)]
 ```
 
-### Game state description
+### Game state description — `describe()`
 
-Add `GameState.describe() -> dict` (or a dedicated dataclass) producing a
-structured, LLM-readable snapshot of the current state. At minimum:
+Add `GameState.describe() -> dict` producing a structured snapshot of the current state.
+The format should be serialisable (JSON-compatible) and complete enough that an LLM can
+reason about strategy without access to any other state.
 
-- Current player, phase, lira, rubies, cart contents, cards in hand, assistant locations
-- Current tile and what can be done there (synthesised from tile state)
-- Other players: locations, rubies (public information)
-- Board: governor/smuggler locations, market demands, mosque tile costs, post office position
-- Outstanding reward choices if any
+**Fields:**
+```
+current_player:
+  color, phase, lira, rubies
+  cart: {red, blue, green, yellow, cart_max}
+  hand: {card_name: count, ...}
+  assistant_locations: [location_numbers]
+  family_location: location_number
 
-The exact format (dict, dataclass, or string) can be decided at implementation time;
-the important thing is that it is computed from the same `GameState` fields as the
-validator, so it cannot go stale.
+other_players: [{color, location, rubies}, ...]   # public info only
+
+board:
+  governor_location: location_number
+  smuggler_location: location_number
+  tile_layout: {location_number: tile_name, ...}
+
+tiles:
+  small_market: {demand: {good: count}, one_cost: int}
+  large_market: {demand: {good: count}, one_cost: int}
+  post_office: {position: int, next_goods: [good_names], next_lira: int}
+  great_mosque: {available_tiles: {good: cost}, ...}
+  small_mosque: {available_tiles: {good: cost}, ...}
+  sultans_palace: {required_count: int, required: {good: count}}
+  gemstone_dealer: {cost: int | null}
+  wainwright: {extensions_remaining: int}
+  caravansary: {discard_pile_top: card_name | null}
+
+outstanding_reward_choices: int
+```
+
+### LLM prompt guide
+
+In addition to `describe()`, the integration layer should provide a static markdown
+explanation of the action format and sentinel values as part of the system prompt or
+alongside the legal actions list. At minimum it should explain:
+
+- What `UNRESOLVED_ROLL` means and that the runner will prompt for the dice result
+- What `UNRESOLVED_DEMAND` means and that the new demand will be input after the trade
+- How to interpret `FountainAction(locations)` vs `GenericTileAction()` at the Fountain
+- The two-step resolution protocol for red tile decisions (once that is resolved above)
+
+The legal actions list itself may also be offered as full enumeration on request — if
+the LLM's response does not match a legal action, the runner can re-query with the
+explicit list rather than failing immediately.
 
 ---
 

--- a/designs/DESIGN-LLM-PLAYER.md
+++ b/designs/DESIGN-LLM-PLAYER.md
@@ -1,0 +1,309 @@
+# Design: LLM Player Support
+
+> **Executive summary:** This plan introduces LLM player support for the Istanbul game
+> engine through three sequential phases: a prerequisite refactor to eliminate the police
+> station temporary-relocation hack, extraction of a pure `is_valid_action()` predicate,
+> and implementation of candidate generators feeding a `legal_actions()` API plus a
+> `describe()` state snapshot. Several action types encode parameters that are either
+> resolved externally (dice rolls, market demand draws) or represent open choices too
+> numerous to enumerate (fountain recall subsets, sultan's palace wildcard goods); a
+> consistent sentinel value strategy for these needs to be agreed on before implementation
+> begins, as it touches both the action data model and the game runner flow. No other
+> external decisions are needed to start Phase 0.
+
+This document describes the plan for enabling an LLM to act as one or more players
+in the Istanbul game engine. The approach is to expose a `legal_actions()` API that
+returns the exact set of valid actions at any point in the game, plus a game-state
+description suitable for LLM consumption.
+
+## Goals
+
+- `GameState.legal_actions() -> list[PlayerAction]` — returns exactly the legal actions
+  available to the current player at this moment (no illegal actions included, no legal
+  actions omitted).
+- `GameState.is_valid_action(action) -> bool` — pure predicate, never raises, replaces
+  assertion-based validation as the source of truth. `take_action()` continues to assert
+  on this, but callers (including the LLM interface) can check without crashing.
+- Clean up the police station temporary-relocation hack as a prerequisite, since it
+  makes the validator structurally awkward.
+
+## Phase 0: Refactor Police Station Temporary Relocation
+
+### Problem
+
+`_handle_police_station_action` (game.py:518–542) temporarily overwrites
+`player_state.location` and the tile's `players` sets so that recursive sub-handlers see
+the player as being at the destination tile. A comment acknowledges this is an oversight.
+This pattern makes it impossible to validate a `PoliceStationAction`'s sub-action without
+actually relocating, and it makes handlers harder to test in isolation.
+
+### Solution: `_execute_tile_action_at(action, location)`
+
+Extract a dispatcher method that routes a tile action to the correct handler, using
+an explicit `location` argument rather than reading `player_state.location`. Both the
+main `take_action()` and the police station handler call this method. Handlers are
+refactored to receive the resolved `tile` and `tile_state` as parameters instead of
+computing them from player location.
+
+```
+_execute_tile_action_at(action: PlaceTileAction | GreenTileAction, location: Location)
+    tile = location_map[location]
+    tile_state = tile_states[tile]
+    dispatch to the appropriate handler, passing tile and tile_state explicitly
+```
+
+**Changes to handlers:** Each `_handle_X` method receives `tile: Tile` and
+`tile_state: TileState` as parameters, dropping the `self.location_map[player_state.location]`
+call. The tile-identity assertions (`assert tile is Tile.FOO`) become internal sanity checks
+rather than the primary validation mechanism.
+
+**Police station handler becomes:**
+
+```python
+def _handle_police_station_action(self, action: PoliceStationAction) -> None:
+    # validate and move family member ...
+    self.family_member_acting = True
+    self._execute_tile_action_at(action.action, action.location)
+    self.family_member_acting = False
+    # no player relocation needed
+```
+
+**Main take_action phase 3 dispatch becomes:**
+
+```python
+# instead of the current generic_action_map + match block:
+self._execute_tile_action_at(action, self.current_player_location)
+self._encounter_family_members()
+```
+
+This phase 0 refactor should be covered by existing tests (behaviour is unchanged).
+
+---
+
+## Phase 1: Pure Validator — `is_valid_action`
+
+### Structure
+
+Add `GameState.is_valid_action(action: PlayerAction) -> bool` as a pure predicate.
+It never raises and never mutates state. `take_action()` keeps its existing behaviour
+(assert-on-invalid) but gates on `is_valid_action()` rather than inline assertions.
+
+The validator has two layers, mirroring the existing two-level validation:
+
+1. **Phase/type check** — delegates to `TurnState.valid_action()` (already exists).
+2. **State check** — for each action type, check the preconditions that the handler
+   currently asserts.
+
+### Preconditions by action type
+
+**Cross-cutting:**
+- `ChooseReward`: `outstanding_reward_choices > 0`; choice is LIRA or a valid Card
+- `YieldTurn`: phase in {2, 4} and `outstanding_reward_choices == 0`
+- All others: `not completed`
+
+**Phase 1 actions:**
+- `Move(loc, skip)`: `taxicab_dist(current, loc) in {1, 2}`
+- `ExtraMoveCardAction(move)`: has EXTRA_MOVE card; `taxicab_dist(current, move.tile) in {3, 4}`
+- `NoMoveCardAction`: has NO_MOVE card
+- `ReturnAssistantCardAction(from_tile)`: has RETURN_ASSISTANT card; player has assistant at `from_tile`
+- `OneGoodCardAction(good)`: has ONE_GOOD card
+- `FiveLiraCardAction`: has FIVE_LIRA card
+- `ArrestFamilyCardAction(reward)`: has ARREST_FAMILY card; family not at police station
+- `YellowTileAction(from_tile)`: has YELLOW tile; has assistant at `from_tile`; lira >= 2
+
+**Phase 2 actions:**
+- `Pay`: other players at current tile; lira >= (players_at_tile - 1) * 2
+
+**Phase 3 tile actions** (all also require being at the right tile):
+
+| Action | Key preconditions |
+|--------|------------------|
+| `GenericTileAction` at POST_OFFICE | at Post Office (always succeeds) |
+| `GenericTileAction` at warehouses | at correct warehouse |
+| `GenericTileAction` at WAINWRIGHT | lira >= 7; cart_max < 5; extensions remaining |
+| `GenericTileAction` at GEMSTONE_DEALER | `dealer_state.cost is not None`; lira >= cost |
+| `GenericTileAction` at FOUNTAIN | at Fountain |
+| `MosqueAction(good)` | at mosque; player lacks that tile; mosque has that tile available; player has enough goods |
+| `BlackMarketAction(good, roll)` | at Black Market; if RedTileAction roll: has red tile |
+| `CaravansaryAction(gains, cost)` | at Caravansary; has `cost` card; discard pile depth >= count of DISCARD gains; not awaiting_discard |
+| `MarketAction(goods, new_demand)` | at Small or Large Market; player has those goods; goods ≤ demand for each type; not expecting_demand |
+| `TeaHouseAction(call, roll)` | at Tea House; call in {3..12}; if RedTileAction roll: has red tile |
+| `SultansPalaceAction(goods)` | at Sultan's Palace; `required()` not None; player has enough goods matching requirement |
+| `FountainAction(locs)` | at Fountain; `locs ⊆ player.assistant_locations` |
+| `PoliceStationAction(location, sub)` | at Police Station; player has family at police station; location != police_station; `_can_do_tile_action_at(sub, location)` |
+| `SkipTileAction` | always valid in phase 3 |
+| `GreenTileAction(good)` | has GREEN tile; at a warehouse tile; lira >= 2 |
+| `SellAnyCardAction(market_action)` | has SELL_ANY card; at SMALL_MARKET; market_action valid at that tile |
+| `DoubleCardAction(card, actions)` | has the card; at the right tile; each sub-action independently valid at that tile |
+
+**Phase 4 actions:**
+- `EncounterGovernor(gain, cost, roll)`: governor at current tile; if cost is Pay: lira >= 2; if cost is Card: has that card
+- `EncounterSmuggler(gain, cost, roll)`: smuggler at current tile; if cost is Pay: lira >= 2; if cost is Good: has that good in cart
+
+### Implementation note
+
+`_can_do_tile_action_at(action, location) -> bool` is a private helper that performs
+phase 3 validation at an arbitrary location (used both by the main validator and by the
+PoliceStationAction validator for its sub-action). This directly mirrors
+`_execute_tile_action_at` in structure.
+
+---
+
+## Phase 2: Candidate Generators
+
+`legal_actions()` = filter(`is_valid_action`, `_candidate_actions()`).
+
+`_candidate_actions()` generates a superset of plausible actions for the current
+phase, without worrying about whether all of them pass validation. The validator is
+the source of correctness; the generator just needs to cover all possibilities.
+
+### By phase
+
+**Phase 1:**
+- `Move(loc, skip)` for all 16 locations × {True, False}
+- If has EXTRA_MOVE: `ExtraMoveCardAction(Move(loc, skip))` for all 16 × {True, False}
+- If has NO_MOVE: `NoMoveCardAction(True)`, `NoMoveCardAction(False)`
+- If has RETURN_ASSISTANT: `ReturnAssistantCardAction(loc)` for each location in `assistant_locations`
+- Phase-all cards (see below)
+- If `yield_required`: only phase-all cards + `YieldTurn()`
+
+**Phase 2:**
+- `YieldTurn()`
+- `Pay()`
+- Phase-all cards
+
+**Phase 3:**
+- `SkipTileAction()`
+- Tile-specific candidates for current tile (see tile generators below)
+- Phase-all cards
+- If at a warehouse and has GREEN tile: `GreenTileAction(good)` for each Good (except BLUE)
+- If has SELL_ANY and at SMALL_MARKET: `SellAnyCardAction(action)` for each valid market candidate
+- If has DOUBLE_SULTAN and at SULTANS_PALACE: `DoubleCardAction(DOUBLE_SULTAN, (a, a))` for valid palace action `a`
+- If has DOUBLE_PO and at POST_OFFICE: `DoubleCardAction(DOUBLE_PO, (GenericTileAction(), GenericTileAction()))`
+- If has DOUBLE_DEALER and at GEMSTONE_DEALER: `DoubleCardAction(DOUBLE_DEALER, (GenericTileAction(), GenericTileAction()))`
+
+**Phase 4 / outstanding rewards:**
+- If `outstanding_reward_choices > 0`: `ChooseReward(LIRA)` + `ChooseReward(card)` for each Card
+- If governor at tile: `EncounterGovernor(...)` — see note on rolls below
+- If smuggler at tile: `EncounterSmuggler(...)` — see note on rolls below
+- `YieldTurn()`
+- Phase-all cards
+
+**Phase-all cards** (valid in phases 1, 2, 3, 4 when yield_required or not):
+- If has ONE_GOOD: `OneGoodCardAction(good)` for each Good
+- If has FIVE_LIRA: `FiveLiraCardAction()`
+- If has ARREST_FAMILY: `ArrestFamilyCardAction(ChooseReward(choice))` for each choice
+- If has YELLOW tile: `YellowTileAction(loc)` for each location in `assistant_locations`
+
+### Tile-specific candidate generators
+
+| Tile | Candidates generated |
+|------|---------------------|
+| POST_OFFICE | `GenericTileAction()` |
+| FABRIC / SPICE / FRUIT WAREHOUSE | `GenericTileAction()` |
+| WAINWRIGHT | `GenericTileAction()` |
+| FOUNTAIN | `FountainAction(RECALL_ALL)` sentinel entry only (players can have up to 5 assistants in the field, making full subset enumeration impractical) |
+| GEMSTONE_DEALER | `GenericTileAction()` |
+| GREAT_MOSQUE / SMALL_MOSQUE | `MosqueAction(good)` for each Good available at that mosque |
+| BLACK_MARKET | `BlackMarketAction(good, roll)` for each of {RED, GREEN, YELLOW} — roll is a placeholder (see below) |
+| CARAVANSARY | `CaravansaryAction(gains, cost)` for each card in hand as cost, each valid gain combination |
+| SMALL_MARKET / LARGE_MARKET | `MarketAction(goods, new_demand)` for each non-empty subset of (player goods ∩ demand) — `new_demand` is a placeholder (see below) |
+| TEA_HOUSE | `TeaHouseAction(call, roll)` for call in {3..12} — roll is a placeholder (see below) |
+| SULTANS_PALACE | `SultansPalaceAction(AUTO_GOODS)` sentinel entry (wildcard slots make enumerating valid combinations complex; runner resolves goods) |
+| POLICE_STATION | `PoliceStationAction(loc, sub)` for each non-police-station location × each valid sub-action candidate at that tile |
+
+### Sentinel values for open or externally-resolved parameters
+
+Several action types contain parameters that are either resolved by external game
+mechanics (dice, drawn cards) or represent choices that are too numerous to enumerate
+cleanly in a legal-actions list. For all of these the `legal_actions()` API uses a
+named sentinel value in place of the actual parameter. The validator treats any sentinel
+as vacuously valid for that parameter slot; the game runner fills in real values before
+calling `take_action()`.
+
+A module-level `SENTINEL` marker (or per-field constants) should be defined before
+implementation begins so that all action types use a consistent approach.
+
+| Action | Sentinel parameter | Who resolves it |
+|--------|--------------------|-----------------|
+| `TeaHouseAction.roll` | `UNRESOLVED_ROLL` | Game runner rolls dice after LLM picks `call` |
+| `BlackMarketAction.roll` | `UNRESOLVED_ROLL` | Game runner rolls dice after LLM picks good |
+| `EncounterGovernor.roll` | `UNRESOLVED_ROLL` | Game runner rolls dice |
+| `EncounterSmuggler.roll` | `UNRESOLVED_ROLL` | Game runner rolls dice |
+| `MarketAction.new_demand` | `UNRESOLVED_DEMAND` | Game runner draws demand card after trade |
+| `FountainAction.assistant_locations` | `RECALL_ALL` | Validator/handler reads all player assistant locations |
+| `SultansPalaceAction.goods` | `AUTO_GOODS` | Game runner (or handler) picks any valid goods combination from player's cart |
+
+**Fountain:** A player may have up to 5 assistants on the board (starting stack of 4,
++1 from the Blue mosque tile), yielding up to 32 possible subset choices. Enumerating
+all subsets adds noise without benefit to the LLM. `legal_actions()` returns a single
+`FountainAction(RECALL_ALL)` sentinel entry; if partial recall is ever needed the LLM
+can request it via a separate mechanism.
+
+**Sultan's Palace wildcards:** When `required_count` exceeds 4 the requirement includes
+`None` wildcard slots (any good). The LLM does not need to reason about which specific
+good fills each wildcard; `AUTO_GOODS` signals the runner to pick any valid combination
+from the player's cart.
+
+**Validator behaviour:** The validator skips the specific-value checks for sentinel
+slots (e.g., roll validation, demand validation, goods-match validation) and only checks
+the non-sentinel preconditions (correct tile, sufficient resources, etc.). This must be
+documented clearly so future implementors do not accidentally tighten the validator
+to reject sentinels.
+
+---
+
+## Phase 3: Public API and Game State Observation
+
+### `legal_actions() -> list[PlayerAction]`
+
+```python
+def legal_actions(self) -> list[PlayerAction]:
+    """Return all legal actions available to the current player right now."""
+    return [a for a in self._candidate_actions() if self.is_valid_action(a)]
+```
+
+### Game state description
+
+Add `GameState.describe() -> dict` (or a dedicated dataclass) producing a
+structured, LLM-readable snapshot of the current state. At minimum:
+
+- Current player, phase, lira, rubies, cart contents, cards in hand, assistant locations
+- Current tile and what can be done there (synthesised from tile state)
+- Other players: locations, rubies (public information)
+- Board: governor/smuggler locations, market demands, mosque tile costs, post office position
+- Outstanding reward choices if any
+
+The exact format (dict, dataclass, or string) can be decided at implementation time;
+the important thing is that it is computed from the same `GameState` fields as the
+validator, so it cannot go stale.
+
+---
+
+## Testing
+
+All phases must be covered by tests:
+
+- **Phase 0:** Existing tests should pass unchanged after refactor.
+- **Phase 1:** Unit tests for `is_valid_action` covering valid and invalid cases for each
+  action type. Verify that `is_valid_action` agrees with `take_action` (no action that
+  passes the validator should raise when taken, and vice versa) — a property test is
+  well-suited here.
+- **Phase 2:** `legal_actions()` is tested against known game states, verifying no legal
+  action is omitted and no illegal action is included.
+- **Phase 3:** `describe()` is a snapshot test.
+
+---
+
+## File layout
+
+New code belongs in the `istanbul_game` package:
+
+| File | Contents |
+|------|----------|
+| `istanbul_game/game.py` | `is_valid_action`, `_can_do_tile_action_at`, `_execute_tile_action_at`, `_candidate_actions`, `legal_actions`, `describe`; refactored handlers |
+| `istanbul_game/candidates.py` | Candidate generator helpers (if game.py becomes unwieldy) |
+| `tests/test_validator.py` | Validator unit tests |
+| `tests/test_legal_actions.py` | Legal actions integration tests |
+
+The phase 0 police station refactor stays entirely within `game.py`.


### PR DESCRIPTION
## Summary

- Adds `designs/` subdirectory for design documents
- Documents a phased plan for enabling LLM-controlled players: police station refactor (Phase 0), pure `is_valid_action()` predicate (Phase 1), `legal_actions()` candidate generators (Phase 2), and `describe()` state snapshot (Phase 3)
- Includes sentinel value strategy for action parameters that are externally resolved (dice rolls, market demand) or too numerous to enumerate cleanly (fountain recall subsets, sultan's palace wildcard goods)

## Test plan

- [ ] No code changes in this PR; review the design document for correctness and completeness before implementation begins
- [ ] Confirm the sentinel value approach and naming conventions before Phase 1 work starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)